### PR TITLE
Avoid dispatcher initialization when running on Piano SDK 3.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.1
+-----
+
+* Added verification to ensure the dispatcher is running on the right Piano SDK version (3.2.1 or older) while waiting for us to support the new version (3.3.0+).
+
 1.0.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ A "ready-to-go" dispatcher that reflect event from the Batch SDK to the Piano da
  - Android Studio 3.0+
  - Android 16+
  - Batch Android SDK 1.19.3+
- - Piano Analytics 3.1.0+
+ - Piano Analytics [3.1.0...3.2.1]
+
+> The Android Piano Analytics dispatcher requires version 3.2.1 or older of the Piano SDK since it does NOT support yet the rewritten Kotlin Piano SDK.
 
 # Installation
 Gradle (recommended)
 
 ```
-implementation 'com.batch.android:piano-dispatcher:1.0.0'
+implementation 'com.batch.android:piano-dispatcher:1.0.1'
 ```
 
 Read our [setup documentation](https://doc.batch.com/) to follow a step by step tutorial for integrating Batch features into your app.

--- a/piano-dispatcher/src/main/java/com/batch/android/dispatcher/piano/PianoRegistrar.java
+++ b/piano-dispatcher/src/main/java/com/batch/android/dispatcher/piano/PianoRegistrar.java
@@ -30,6 +30,12 @@ public class PianoRegistrar implements DispatcherRegistrar {
     @Override
     public BatchEventDispatcher getDispatcher(Context context) {
         if (instance == null) {
+            // Abort initialization when the App is running on the new Piano SDK.
+            if (isNewPianoSDKPresent()) {
+                Log.e("Batch", "PianoDispatcher - It looks like you are using an unsupported version of the Piano SDK." +
+                        " This dispatcher requires version 3.2.1 or older. Aborting initialization.");
+                return null;
+            }
             instance = new PianoDispatcher(context);
             instance.enableBatchCustomEvents(getBooleanMetaDataInfo(context, CUSTOM_EVENT_ENABLED_METADATA, false));
             instance.enableBatchOnSiteAdsEvents(getBooleanMetaDataInfo(context, ONSITE_AD_EVENT_ENABLED_METADATA, true));
@@ -58,5 +64,18 @@ public class PianoRegistrar implements DispatcherRegistrar {
             Log.e("Batch", "Error while parsing meta-data info", e);
         }
         return fallback;
+    }
+
+    /**
+     * Check if the new Kotlin Piano SDK (3.3.0+) is present.
+     * @return Whether the new Piano SDK is present.
+     */
+    private boolean isNewPianoSDKPresent() {
+        try {
+            Class.forName("io.piano.android.analytics.PianoAnalytics");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
 - Added verification to avoid starting on unsupported version of the Piano SDK.